### PR TITLE
fix(package.json): fix md-file-converter semver range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3594,9 +3594,9 @@
             "dev": true
         },
         "md-file-converter": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/md-file-converter/-/md-file-converter-1.0.1.tgz",
-            "integrity": "sha512-6QUasSvSNXv8Bqdoq9Dlnv5XR3ZIYbKIDjO7cvCX3WbTKpAqDfvdco5SZsJ0+07hLDSMPXJT5hw4FLiG10BJDA==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/md-file-converter/-/md-file-converter-1.2.0.tgz",
+            "integrity": "sha512-Dg2t3mF9NtVtDbuMdVjeikveuY7EQbmQ2/X1B2muX3AuTnOMkR3WmcmViXOqWq3/XK5DrmSk2O1PKAjUhIOc5w==",
             "requires": {
                 "commander": "^2.19.0",
                 "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     },
     "dependencies": {
         "marked": "^0.6.0",
-        "md-file-converter": "1.0.1"
+        "md-file-converter": "^1.2.0"
     },
     "devDependencies": {
         "@commitlint/cli": "^7.5.0",


### PR DESCRIPTION
allows host project to catch mdfc CLI updates without needing a mdfc-map-to-html update