### PR TITLE
fix(marked-renderer-impl): fix link function

### DIFF
--- a/bin/marked-renderer-html-impl.js
+++ b/bin/marked-renderer-html-impl.js
@@ -1,8 +1,11 @@
 'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 function link(href, title, text) {
-    const htmlHref = href.substring(0, href.length - 2) + 'html';
-    return `<a href="${htmlHref}">${text}</a>`;
+    if (href.substring(href.length - 3, href.length) === '.md') {
+        const htmlHref = href.substring(0, href.length - 2) + 'html';
+        return `<a href="${htmlHref}">${text}</a>`;
+    }
+    return `<a href="${href}">${text}</a>`;
 }
 exports.default = {
     link

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     },
     "scripts": {
         "cz-commit": "git-cz",
-        "start": "node ./node_modules/.bin/mdfc convert '../../../dist' 'test-news.md'",
+        "start": "node ./node_modules/.bin/mdfc convert '../../../dist' 'tests/actual-files/doc-w-tables/javascript-overview.md'",
         "lint": "./node_modules/.bin/eslint -c .eslintrc.json tests/*.spec.js",
         "lint-ts": "./node_modules/tslint/bin/tslint -t stylish -c tslint.json src/**/*.ts src/*.ts",
         "compile": "rimraf 'dist/' && ./node_modules/.bin/tsc --pretty --project 'tsconfig-dev.json'",

--- a/src/marked-renderer-html-impl.ts
+++ b/src/marked-renderer-html-impl.ts
@@ -5,8 +5,12 @@
  */
 
 function link(href: string, title: string, text: string): string {
-    const htmlHref = href.substring(0, href.length - 2) + 'html';
-    return `<a href="${htmlHref}">${text}</a>`;
+    if (href.substring(href.length - 3, href.length) === '.md') {
+        const htmlHref = href.substring(0, href.length - 2) + 'html';
+        return `<a href="${htmlHref}">${text}</a>`;
+    }
+
+    return `<a href="${href}">${text}</a>`;
 }
 
 export default {

--- a/tests/e2e-convert-map-to-html.spec.js
+++ b/tests/e2e-convert-map-to-html.spec.js
@@ -14,7 +14,7 @@ describe('command :: "md-file-converter convert \'../../../dist\' \'tests/actual
         expect(result.stdout).to.include('Processing files done.');
     });
 
-    it('should output a final html file with a content equal to tests/expected-files/map-to-html/news/test-news.html content', async () => {
+    it('should output a final html file with a content equal to tests/expected-files/news/test-news.html content', async () => {
         const results = await Promise.all([
             fsp.readFile('tests/actual-files/news/test-news.html', { encoding: 'utf-8' }),
             fsp.readFile('tests/expected-files/news/test-news.html', { encoding: 'utf-8' })

--- a/tests/expected-files/css-support/test-news-with-css.html
+++ b/tests/expected-files/css-support/test-news-with-css.html
@@ -4,7 +4,7 @@
 <p>Github héberge désormais plus de 80 millions de dépôts, lui permettant de disposer de statistiques inégalées sur l’usage<br>et le contenu des dépôts.</p>
 <p>Le 5 mars dernier, GitHub a dévoilé sur son blog un nouvel outil nommé git-sizer. Cet outil écrit en Go analyse le conteun<br>du dépôt dans lequel il est exécuté et fournit un rapport affichant une vue globale des métriques principales associé à<br>un indicateur d’alerte relatif à l’usage standard constaté sur leur plateforme.</p>
 <h2>installation</h2>
-<p>L’installation de git-sizer se fait très simplement en téléchargeant le binaire correspondant à votre système ou bien<br>en compilant depuis les sources. (<a href="https://github.com/github/git-sizer/releashtml">https://github.com/github/git-sizer/releases</a>).</p>
+<p>L’installation de git-sizer se fait très simplement en téléchargeant le binaire correspondant à votre système ou bien<br>en compilant depuis les sources. (<a href="https://github.com/github/git-sizer/releases">https://github.com/github/git-sizer/releases</a>).</p>
 <p>A noter que la version locale du CLI git doit être au minimum la 2.6.</p>
 <p>Il est conseillé d’ajouter le répertoire d’installation du binaire au PATH pour un usage plus facile.</p>
 <h2>usage</h2>

--- a/tests/expected-files/doc-w-tables/javascript-overview.html
+++ b/tests/expected-files/doc-w-tables/javascript-overview.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html><html><head><meta charset="utf-8"><title>javascript-overview</title></head><body><article><h1>JavaScript - overview</h1>
 <h2>organizations</h2>
 <h3>TC39</h3>
-<p><a href="http://www.ecma-international.org/memento/tc39.hhtml">TC39 webpage on www.ecma-international.org</a></p>
-<p><a href="https://github.com/tchtml">Ecma TC39 on GitHub</a></p>
+<p><a href="http://www.ecma-international.org/memento/tc39.htm">TC39 webpage on www.ecma-international.org</a></p>
+<p><a href="https://github.com/tc39">Ecma TC39 on GitHub</a></p>
 <blockquote>
 <p>Technical Committee 39. Caretaker for many standards: ECMAScript (ECMA-262), Intl (ECMA-402), JSON (ECMA-404), etc.</p>
 </blockquote>
 <h3>The JS Foundation</h3>
-<p><a href="https://js.foundatiohtml">The JS Foundation</a></p>
+<p><a href="https://js.foundation/">The JS Foundation</a></p>
 <blockquote>
 <p>The JS Foundation supports some of the most important projects in the JavaScript ecosystem.</p>
 </blockquote>
@@ -29,9 +29,9 @@
 <blockquote>
 <p>ECMA is an international standards body (much like ISO, IETF, W3C or WHATWG, for instance).</p>
 </blockquote>
-<p><a href="https://fr.wikipedia.org/wiki/ECMAScrihtml">Wikipedia</a>, <a href="https://developer.mozilla.org/fr/docs/Web/JavaScript/Language_Resourchtml">Sources</a></p>
+<p><a href="https://fr.wikipedia.org/wiki/ECMAScript">Wikipedia</a>, <a href="https://developer.mozilla.org/fr/docs/Web/JavaScript/Language_Resources">Sources</a></p>
 <h3>ECMA-262 publications</h3>
-<p>Listed <a href="https://www.ecma-international.org/publications/standards/Ecma-262-arch.hhtml">on the ECMA internatinal website</a>.</p>
+<p>Listed <a href="https://www.ecma-international.org/publications/standards/Ecma-262-arch.htm">on the ECMA internatinal website</a>.</p>
 <table>
 <thead>
 <tr>
@@ -45,19 +45,19 @@
 <td>ES1</td>
 <td>ECMA-262</td>
 <td>1997</td>
-<td><a href="https://www.ecma-international.org/publications/files/ECMA-ST-ARCH/ECMA-262,%201st%20edition,%20June%201997.phtml">PDF</a></td>
+<td><a href="https://www.ecma-international.org/publications/files/ECMA-ST-ARCH/ECMA-262,%201st%20edition,%20June%201997.pdf">PDF</a></td>
 </tr>
 <tr>
 <td>ES2</td>
 <td>ECMA-262</td>
 <td>1998</td>
-<td><a href="https://www.ecma-international.org/publications/files/ECMA-ST-ARCH/ECMA-262,%202nd%20edition,%20August%201998.phtml">PDF</a></td>
+<td><a href="https://www.ecma-international.org/publications/files/ECMA-ST-ARCH/ECMA-262,%202nd%20edition,%20August%201998.pdf">PDF</a></td>
 </tr>
 <tr>
 <td>ES3</td>
 <td>ECMA-262</td>
 <td>1999</td>
-<td><a href="https://www.ecma-international.org/publications/files/ECMA-ST-ARCH/ECMA-262,%203rd%20edition,%20December%201999.phtml">PDF</a></td>
+<td><a href="https://www.ecma-international.org/publications/files/ECMA-ST-ARCH/ECMA-262,%203rd%20edition,%20December%201999.pdf">PDF</a></td>
 </tr>
 <tr>
 <td>ES4</td>
@@ -69,50 +69,50 @@
 <td>ES5</td>
 <td>ECMA-262</td>
 <td>2009</td>
-<td><a href="https://www.ecma-international.org/publications/files/ECMA-ST-ARCH/ECMA-262%205th%20edition%20December%202009.phtml">PDF</a></td>
+<td><a href="https://www.ecma-international.org/publications/files/ECMA-ST-ARCH/ECMA-262%205th%20edition%20December%202009.pdf">PDF</a></td>
 </tr>
 <tr>
 <td>ES5.1</td>
 <td>ECMA-262</td>
 <td>2011</td>
-<td><a href="http://www.ecma-international.org/ecma-262/5.1/Ecma-262.phtml">PDF</a>, <a href="https://www.ecma-international.org/ecma-262/5.html">HTML</a>, <a href="https://es5.github.ihtml">Annotated HTML</a></td>
+<td><a href="http://www.ecma-international.org/ecma-262/5.1/Ecma-262.pdf">PDF</a>, <a href="https://www.ecma-international.org/ecma-262/5.1/">HTML</a>, <a href="https://es5.github.io/">Annotated HTML</a></td>
 </tr>
 <tr>
 <td>ES6</td>
 <td>ECMA-262 2015</td>
 <td>2015</td>
-<td><a href="http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.phtml">PDF</a>, <a href="http://www.ecma-international.org/ecma-262/6.0/index.hthtml">HTML</a>, <a href="https://github.com/lukehoban/es6featurhtml">ES6 features list</a>, <a href="http://es6-features.ohtml">ES6 Features list over ES5</a></td>
+<td><a href="http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf">PDF</a>, <a href="http://www.ecma-international.org/ecma-262/6.0/index.html">HTML</a>, <a href="https://github.com/lukehoban/es6features">ES6 features list</a>, <a href="http://es6-features.org">ES6 Features list over ES5</a></td>
 </tr>
 <tr>
 <td>ES7</td>
 <td>ECMA-262 2016</td>
 <td>2016</td>
-<td><a href="https://www.ecma-international.org/ecma-262/7.html">HTML</a></td>
+<td><a href="https://www.ecma-international.org/ecma-262/7.0/">HTML</a></td>
 </tr>
 <tr>
 <td>ES8</td>
 <td>ECMA-262 2017</td>
 <td>2017</td>
-<td><a href="https://www.ecma-international.org/ecma-262/8.html">HTML</a></td>
+<td><a href="https://www.ecma-international.org/ecma-262/8.0/">HTML</a></td>
 </tr>
 <tr>
 <td>ES9</td>
 <td>ECMA-262 2018</td>
 <td>2018</td>
-<td><a href="https://www.ecma-international.org/ecma-262/9.html">HTML</a></td>
+<td><a href="https://www.ecma-international.org/ecma-262/9.0/">HTML</a></td>
 </tr>
 <tr>
 <td>ES.Next</td>
 <td>ECMA-262 2019</td>
 <td>2019 ?</td>
-<td><a href="https://tc39.github.io/ecma26html">Draft</a>, <a href="http://2ality.com/2018/02/ecmascript-2019.hthtml">Feature watch: ECMAScript 2019</a></td>
+<td><a href="https://tc39.github.io/ecma262/">Draft</a>, <a href="http://2ality.com/2018/02/ecmascript-2019.html">Feature watch: ECMAScript 2019</a></td>
 </tr>
 </tbody></table>
-<p><a href="https://www.ecma-international.org/news/index.hthtml">Publication announced in the ECMA news page</a>. </p>
+<p><a href="https://www.ecma-international.org/news/index.html">Publication announced in the ECMA news page</a>. </p>
 <p>Occurs following a general assembly meeting. The last to date was the 115th General Assembly held in Geneva, June 27, 2018.</p>
-<p>They approved the <a href="https://www.ecma-international.org/ecma-262/9.html">ECMA-262 9th edition</a> - ECMAScript® 2018 Language Specification.</p>
+<p>They approved the <a href="https://www.ecma-international.org/ecma-262/9.0/">ECMA-262 9th edition</a> - ECMAScript® 2018 Language Specification.</p>
 <h3>The TC39 Process</h3>
-<p><a href="https://tc39.github.io/process-documenhtml">The TC39 Process</a></p>
+<p><a href="https://tc39.github.io/process-document/">The TC39 Process</a></p>
 <table>
 <thead>
 <tr>
@@ -141,7 +141,7 @@
 <td>Full Test262 coverage, 2+ shipping implementations (e.g. V8 + SpiderMonkey), significant real-world usage feedback, Spec Editor imprimatur. Usually goes into the next feature freeze (January or March).</td>
 </tr>
 </tbody></table>
-<p>ECMAScript proposals are tracked <a href="https://github.com/tc39/proposahtml">in a dedicated repository on github</a>.</p>
+<p>ECMAScript proposals are tracked <a href="https://github.com/tc39/proposals">in a dedicated repository on github</a>.</p>
 <p>The <a href="https://github.com/tc39/proposals/blob/master/finished-proposals.html"><code>finished-proposals.md</code></a> file can be seen as a changelog between specs yearly versions.</p>
 <h2>Impl</h2>
 <p>ECMAScript needs an engine to be executed.</p>
@@ -155,7 +155,7 @@
 </tr>
 </thead>
 <tbody><tr>
-<td>V8 <a href="https://v8project.blogspot.fhtml">(blog officiel)</a></td>
+<td>V8 <a href="https://v8project.blogspot.fr/">(blog officiel)</a></td>
 <td>Chrome, NodeJS</td>
 </tr>
 <tr>
@@ -177,63 +177,63 @@
 </tbody></table>
 <h3>JIT</h3>
 <p>Just In Time. An engine like V8 compile JavaScript code into machine code on the fly instead of interpreting it like old engines.</p>
-<p><a href="http://thibaultlaurens.github.io/javascript/2013/04/29/how-the-v8-engine-workhtml">How the V8 engine works? - thibaultlaurens.github.io - 20130429</a></p>
-<p><a href="https://en.wikipedia.org/wiki/Chrome_html">Chrome V8 - en.wikipedia.org</a></p>
-<p><a href="https://hacks.mozilla.org/2017/02/a-crash-course-in-just-in-time-jit-compilerhtml">A crash course in just-in-time (JIT) compilers - hacks.mozilla.org - Lin Clark - 20170228</a></p>
+<p><a href="http://thibaultlaurens.github.io/javascript/2013/04/29/how-the-v8-engine-works/">How the V8 engine works? - thibaultlaurens.github.io - 20130429</a></p>
+<p><a href="https://en.wikipedia.org/wiki/Chrome_V8">Chrome V8 - en.wikipedia.org</a></p>
+<p><a href="https://hacks.mozilla.org/2017/02/a-crash-course-in-just-in-time-jit-compilers/">A crash course in just-in-time (JIT) compilers - hacks.mozilla.org - Lin Clark - 20170228</a></p>
 <blockquote>
 <p>explain diff between interpretation vs compilation and how JIT plugs into this.</p>
 <p>interpreter better startup but slower runtime (compile stupidly every LoC on the fly)</p>
 <p>compiler slower startup but there is lots of room for optimizations</p>
 <p>JIT tries do be between them getting the best of the 2 worlds</p>
 </blockquote>
-<p><a href="https://tech.mozfr.org/post/2017/03/08/Un-petit-cours-accelere-de-compilation-a-la-volee-%28JIT%html">Un petit cours accéléré de compilation à la volée (JIT) - tech.mozfr.org - 20170308</a></p>
+<p><a href="https://tech.mozfr.org/post/2017/03/08/Un-petit-cours-accelere-de-compilation-a-la-volee-%28JIT%29">Un petit cours accéléré de compilation à la volée (JIT) - tech.mozfr.org - 20170308</a></p>
 <blockquote>
 <p>trad fr du précédent</p>
 </blockquote>
 <h3>Features Comparators / Lists</h3>
 <ul>
-<li><a href="http://kangax.github.io/compat-tabhtml">kangax.github.io</a></li>
-<li><a href="http://es6-features.ohtml">ES6 Features list over ES5</a></li>
-<li><a href="https://medium.freecodecamp.org/the-complete-javascript-handbook-f26b2c7171html">The Complete JavaScript Handbook - medium.freecodecamp.org - 20181030</a></li>
+<li><a href="http://kangax.github.io/compat-table">kangax.github.io</a></li>
+<li><a href="http://es6-features.org">ES6 Features list over ES5</a></li>
+<li><a href="https://medium.freecodecamp.org/the-complete-javascript-handbook-f26b2c71719c">The Complete JavaScript Handbook - medium.freecodecamp.org - 20181030</a></li>
 </ul>
 <h3>tooling lists - states of js</h3>
 <ul>
-<li><a href="https://stateofjs.cohtml">The state of js</a></li>
+<li><a href="https://stateofjs.com/">The state of js</a></li>
 </ul>
 <blockquote>
 <p>So we collected data from over 20,000 developers, asking them questions on topics ranging from front-end frameworks and state management, to build tools and testing libraries.</p>
 </blockquote>
 <blockquote>
-<p><a href="https://stateofjs.com/2017/introductiohtml">The state of js 2017</a></p>
+<p><a href="https://stateofjs.com/2017/introduction/">The state of js 2017</a></p>
 </blockquote>
 <ul>
-<li><p><a href="https://ashleynolan.co.uk/blog/frontend-tooling-survey-2018-resulhtml">The Front-End Tooling Survey 2018 - ashleynolan.co.uk/blog</a></p>
+<li><p><a href="https://ashleynolan.co.uk/blog/frontend-tooling-survey-2018-results">The Front-End Tooling Survey 2018 - ashleynolan.co.uk/blog</a></p>
 </li>
-<li><p><a href="http://frontendtools.com/toohtml">frontendtools.com</a></p>
+<li><p><a href="http://frontendtools.com/tools">frontendtools.com</a></p>
 </li>
 </ul>
 <h3>JavaScript parsers</h3>
 <h4>AST (Abstract Syntax Tree)</h4>
-<p>AST is for Abstract Syntax Tree. The concept is transverse to all programming languages. <a href="https://en.wikipedia.org/wiki/Abstract_syntax_trhtml">Cf wikipedia def</a> for example.</p>
-<p><a href="https://astexplorer.nehtml">astexplorer</a></p>
+<p>AST is for Abstract Syntax Tree. The concept is transverse to all programming languages. <a href="https://en.wikipedia.org/wiki/Abstract_syntax_tree">Cf wikipedia def</a> for example.</p>
+<p><a href="https://astexplorer.net/">astexplorer</a></p>
 <p>An online tool to visualize the AST of the pasted code.</p>
 <p>Bundlers (webpack, …) and Linters (ESLint, …) make heavy use of AST parsers tools to do their job.</p>
-<p>Babel is also using this at the point it integrates a parser in his project. This parser was called <a href="https://github.com/babel/babylhtml">Babylon</a> before it was <a href="https://babeljs.io/docs/en/next/babel-parser.hthtml">merged in Babel</a>.</p>
-<p>ESLint is using <a href="https://github.com/eslint/esprhtml">eslint/espree</a>.</p>
+<p>Babel is also using this at the point it integrates a parser in his project. This parser was called <a href="https://github.com/babel/babylon">Babylon</a> before it was <a href="https://babeljs.io/docs/en/next/babel-parser.html">merged in Babel</a>.</p>
+<p>ESLint is using <a href="https://github.com/eslint/espree">eslint/espree</a>.</p>
 <h3>Transpilers</h3>
 <h4>Babel</h4>
-<p><a href="https://babeljs.ihtml">Babel</a> allows you to write your code in ES6/7/8/x, it will generate ES5 compliant code.</p>
+<p><a href="https://babeljs.io/">Babel</a> allows you to write your code in ES6/7/8/x, it will generate ES5 compliant code.</p>
 <h3>Javascript superset</h3>
-<p><a href="https://johnpapa.net/es5-es2015-typescriphtml">Understanding ES5, ES2015 and TypeScript, 2016/03/20 : johnpapa.net</a></p>
+<p><a href="https://johnpapa.net/es5-es2015-typescript/">Understanding ES5, ES2015 and TypeScript, 2016/03/20 : johnpapa.net</a></p>
 <h4>TypeScript</h4>
-<p><a href="http://www.typescriptlang.orhtml">TypeScript</a> include ES6 specs but it enhances it with more features.</p>
+<p><a href="http://www.typescriptlang.org/">TypeScript</a> include ES6 specs but it enhances it with more features.</p>
 <h3>videos</h3>
-<p><a href="https://www.youtube.com/watch?v=PSeU1IJztkI&list=PLklQqdqnBkPgctKh1xIvF4eFGtmvUvE2b&index=1html">Comprendre enfin JavaScript, Thierry Chatel : Devoxx2015</a></p>
+<p><a href="https://www.youtube.com/watch?v=PSeU1IJztkI&list=PLklQqdqnBkPgctKh1xIvF4eFGtmvUvE2b&index=128">Comprendre enfin JavaScript, Thierry Chatel : Devoxx2015</a></p>
 <h3>presentations</h3>
-<p><a href="https://github.com/tdd/confoo2018-es20html">So, what’s new in ES2020? : Christophe Porteneuve - Confoo Montréal 2018</a></p>
-<p><a href="https://youtu.be/iN7b312ZDU4?t=41html">Paris Web 2017 - Alors, qu’y a-t-il dans ES2020 ? - Christophe Porteneuve</a></p>
+<p><a href="https://github.com/tdd/confoo2018-es2020">So, what’s new in ES2020? : Christophe Porteneuve - Confoo Montréal 2018</a></p>
+<p><a href="https://youtu.be/iN7b312ZDU4?t=4134">Paris Web 2017 - Alors, qu’y a-t-il dans ES2020 ? - Christophe Porteneuve</a></p>
 <h2>Learn</h2>
-<p><a href="https://medium.com/javascript-scene/top-javascript-frameworks-topics-to-learn-in-2017-700a397b7html">Top JavaScript Frameworks &amp; Topics to Learn in 2017 : Eric Elliot 20161210</a></p>
-<p><a href="https://medium.com/javascript-scene/learn-javascript-b631a4af11html">Learn JavaScript Essentials (for all skill levels) : Eric Elliot 20140803</a></p>
-<p><a href="https://medium.com/javascript-scene/10-priceless-resources-for-javascript-learners-bbf2f7d7f8html">10 Priceless Resources for JavaScript Learners : Eric Elliot 20160421</a></p>
+<p><a href="https://medium.com/javascript-scene/top-javascript-frameworks-topics-to-learn-in-2017-700a397b711">Top JavaScript Frameworks &amp; Topics to Learn in 2017 : Eric Elliot 20161210</a></p>
+<p><a href="https://medium.com/javascript-scene/learn-javascript-b631a4af11f2">Learn JavaScript Essentials (for all skill levels) : Eric Elliot 20140803</a></p>
+<p><a href="https://medium.com/javascript-scene/10-priceless-resources-for-javascript-learners-bbf2f7d7f84e">10 Priceless Resources for JavaScript Learners : Eric Elliot 20160421</a></p>
 </article></body></html>

--- a/tests/expected-files/faq/section-001/001.q003.html
+++ b/tests/expected-files/faq/section-001/001.q003.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html><html><head><meta charset="utf-8"><title>001.q003</title></head><body><article><h1>FAQ Git pour developpez.com</h1>
 <h2>1 Généralités</h2>
 <h3>Où trouver de la documentation pour Git ?</h3>
-<p>Le site officiel est disponible à l’adresse <a href="https://git-scm.cohtml">https://git-scm.com/</a>. La documentation est hébergée <a href="https://git-scm.com/dhtml">au même endroit</a>.</p>
+<p>Le site officiel est disponible à l’adresse <a href="https://git-scm.com/">https://git-scm.com/</a>. La documentation est hébergée <a href="https://git-scm.com/doc">au même endroit</a>.</p>
 </article></body></html>

--- a/tests/expected-files/faq/section-002/002.q001.html
+++ b/tests/expected-files/faq/section-002/002.q001.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html><html><head><meta charset="utf-8"><title>002.q001</title></head><body><article><h1>FAQ Git pour developpez.com</h1>
 <h2>2 Installation et configuration</h2>
 <h3>Comment installer Git sur Windows ?</h3>
-<p>Téléchargez le client Git approprié depuis <a href="https://git-scm.com/downloahtml">la page officielle</a>, lancez l’installeur et suivez les instructions.</p>
+<p>Téléchargez le client Git approprié depuis <a href="https://git-scm.com/downloads">la page officielle</a>, lancez l’installeur et suivez les instructions.</p>
 </article></body></html>

--- a/tests/expected-files/faq/section-002/002.q002.html
+++ b/tests/expected-files/faq/section-002/002.q002.html
@@ -4,7 +4,7 @@
 <p>Il existe plusieurs façons d’installer Git sous macOS.</p>
 <ul>
 <li>La première façon consiste à installer XCode qui inclut Git (Apple Git-xy). Depuis un terminal, saisir la ligne de commande =&gt; <code>xcode-select --install</code>.</li>
-<li>La deuxième façon consiste à utiliser <a href="https://sourceforge.net/projects/git-osx-installehtml">Git-osx-install</a>. Téléchargez le fichier .dmg et lancez l’installation en suivant les instructions.</li>
-<li>La troisième façon consiste à utiliser <a href="https://brew.sh/index_html">Homebrew</a>. En supposant que <a href="https://brew.sh/index_html">Homebrew</a> soit installé, depuis un terminal saisir la ligne de commande =&gt; <code>brew install git</code>.</li>
+<li>La deuxième façon consiste à utiliser <a href="https://sourceforge.net/projects/git-osx-installer/">Git-osx-install</a>. Téléchargez le fichier .dmg et lancez l’installation en suivant les instructions.</li>
+<li>La troisième façon consiste à utiliser <a href="https://brew.sh/index_fr">Homebrew</a>. En supposant que <a href="https://brew.sh/index_fr">Homebrew</a> soit installé, depuis un terminal saisir la ligne de commande =&gt; <code>brew install git</code>.</li>
 </ul>
 </article></body></html>

--- a/tests/expected-files/meta-tags-support/test-news-with-meta-tags.html
+++ b/tests/expected-files/meta-tags-support/test-news-with-meta-tags.html
@@ -4,7 +4,7 @@
 <p>Github héberge désormais plus de 80 millions de dépôts, lui permettant de disposer de statistiques inégalées sur l’usage<br>et le contenu des dépôts.</p>
 <p>Le 5 mars dernier, GitHub a dévoilé sur son blog un nouvel outil nommé git-sizer. Cet outil écrit en Go analyse le conteun<br>du dépôt dans lequel il est exécuté et fournit un rapport affichant une vue globale des métriques principales associé à<br>un indicateur d’alerte relatif à l’usage standard constaté sur leur plateforme.</p>
 <h2>installation</h2>
-<p>L’installation de git-sizer se fait très simplement en téléchargeant le binaire correspondant à votre système ou bien<br>en compilant depuis les sources. (<a href="https://github.com/github/git-sizer/releashtml">https://github.com/github/git-sizer/releases</a>).</p>
+<p>L’installation de git-sizer se fait très simplement en téléchargeant le binaire correspondant à votre système ou bien<br>en compilant depuis les sources. (<a href="https://github.com/github/git-sizer/releases">https://github.com/github/git-sizer/releases</a>).</p>
 <p>A noter que la version locale du CLI git doit être au minimum la 2.6.</p>
 <p>Il est conseillé d’ajouter le répertoire d’installation du binaire au PATH pour un usage plus facile.</p>
 <h2>usage</h2>

--- a/tests/expected-files/news/test-news.html
+++ b/tests/expected-files/news/test-news.html
@@ -4,7 +4,7 @@
 <p>Github héberge désormais plus de 80 millions de dépôts, lui permettant de disposer de statistiques inégalées sur l’usage<br>et le contenu des dépôts.</p>
 <p>Le 5 mars dernier, GitHub a dévoilé sur son blog un nouvel outil nommé git-sizer. Cet outil écrit en Go analyse le conteun<br>du dépôt dans lequel il est exécuté et fournit un rapport affichant une vue globale des métriques principales associé à<br>un indicateur d’alerte relatif à l’usage standard constaté sur leur plateforme.</p>
 <h2>installation</h2>
-<p>L’installation de git-sizer se fait très simplement en téléchargeant le binaire correspondant à votre système ou bien<br>en compilant depuis les sources. (<a href="https://github.com/github/git-sizer/releashtml">https://github.com/github/git-sizer/releases</a>).</p>
+<p>L’installation de git-sizer se fait très simplement en téléchargeant le binaire correspondant à votre système ou bien<br>en compilant depuis les sources. (<a href="https://github.com/github/git-sizer/releases">https://github.com/github/git-sizer/releases</a>).</p>
 <p>A noter que la version locale du CLI git doit être au minimum la 2.6.</p>
 <p>Il est conseillé d’ajouter le répertoire d’installation du binaire au PATH pour un usage plus facile.</p>
 <h2>usage</h2>

--- a/tests/expected-files/script-support/test-news-with-script.html
+++ b/tests/expected-files/script-support/test-news-with-script.html
@@ -4,7 +4,7 @@
 <p>Github héberge désormais plus de 80 millions de dépôts, lui permettant de disposer de statistiques inégalées sur l’usage<br>et le contenu des dépôts.</p>
 <p>Le 5 mars dernier, GitHub a dévoilé sur son blog un nouvel outil nommé git-sizer. Cet outil écrit en Go analyse le conteun<br>du dépôt dans lequel il est exécuté et fournit un rapport affichant une vue globale des métriques principales associé à<br>un indicateur d’alerte relatif à l’usage standard constaté sur leur plateforme.</p>
 <h2>installation</h2>
-<p>L’installation de git-sizer se fait très simplement en téléchargeant le binaire correspondant à votre système ou bien<br>en compilant depuis les sources. (<a href="https://github.com/github/git-sizer/releashtml">https://github.com/github/git-sizer/releases</a>).</p>
+<p>L’installation de git-sizer se fait très simplement en téléchargeant le binaire correspondant à votre système ou bien<br>en compilant depuis les sources. (<a href="https://github.com/github/git-sizer/releases">https://github.com/github/git-sizer/releases</a>).</p>
 <p>A noter que la version locale du CLI git doit être au minimum la 2.6.</p>
 <p>Il est conseillé d’ajouter le répertoire d’installation du binaire au PATH pour un usage plus facile.</p>
 <h2>usage</h2>

--- a/tests/expected-files/title-support/test-news-with-title.html
+++ b/tests/expected-files/title-support/test-news-with-title.html
@@ -4,7 +4,7 @@
 <p>Github héberge désormais plus de 80 millions de dépôts, lui permettant de disposer de statistiques inégalées sur l’usage<br>et le contenu des dépôts.</p>
 <p>Le 5 mars dernier, GitHub a dévoilé sur son blog un nouvel outil nommé git-sizer. Cet outil écrit en Go analyse le conteun<br>du dépôt dans lequel il est exécuté et fournit un rapport affichant une vue globale des métriques principales associé à<br>un indicateur d’alerte relatif à l’usage standard constaté sur leur plateforme.</p>
 <h2>installation</h2>
-<p>L’installation de git-sizer se fait très simplement en téléchargeant le binaire correspondant à votre système ou bien<br>en compilant depuis les sources. (<a href="https://github.com/github/git-sizer/releashtml">https://github.com/github/git-sizer/releases</a>).</p>
+<p>L’installation de git-sizer se fait très simplement en téléchargeant le binaire correspondant à votre système ou bien<br>en compilant depuis les sources. (<a href="https://github.com/github/git-sizer/releases">https://github.com/github/git-sizer/releases</a>).</p>
 <p>A noter que la version locale du CLI git doit être au minimum la 2.6.</p>
 <p>Il est conseillé d’ajouter le répertoire d’installation du binaire au PATH pour un usage plus facile.</p>
 <h2>usage</h2>


### PR DESCRIPTION
the .md to .html replace must occurs only when links ends with .md

fix #15